### PR TITLE
Improve performance avoiding constant split join

### DIFF
--- a/lib/getPreviousValue.js
+++ b/lib/getPreviousValue.js
@@ -80,10 +80,10 @@ const getPreviousValue = (object = {}, changes = [], path = '') => {
         .reduce((current_shortest_path, {path}) => path.length > current_shortest_path.length ? current_shortest_path : path, path);
       const shortest_path_subobjectument = getPathValue(object, shortest_path); //This is the value that have to be reverted
       const rerooted_affected_changes = affected_changes.map(change => ({//now we have to change the path for the changes because the root objectument has changed.
-        path: shortest_path.length > 0 ? change.path.split(shortest_path)[1] : change.path,
+        path: shortest_path.length > 0 ? change.path.split(shortest_path)[1].split('/') : change.path.split('/'),
         old_value: change.old_value,
       }));
-      const old_value = rerooted_affected_changes.reduce((reverted, change) => undo(reverted, change), shortest_path_subobjectument);
+      const old_value = rerooted_affected_changes.reduce((reverted, change) => undo(reverted, change, 1), shortest_path_subobjectument);
       const rerooted_requested_path = shortest_path ? path.split(shortest_path)[1] : path;
       return getPathValue(old_value, rerooted_requested_path);
     }

--- a/lib/getPreviousValue.js
+++ b/lib/getPreviousValue.js
@@ -80,10 +80,10 @@ const getPreviousValue = (object = {}, changes = [], path = '') => {
         .reduce((current_shortest_path, {path}) => path.length > current_shortest_path.length ? current_shortest_path : path, path);
       const shortest_path_subobjectument = getPathValue(object, shortest_path); //This is the value that have to be reverted
       const rerooted_affected_changes = affected_changes.map(change => ({//now we have to change the path for the changes because the root objectument has changed.
-        path: shortest_path.length > 0 ? change.path.split(shortest_path)[1].split('/') : change.path.split('/'),
+        path_parts: shortest_path.length > 0 ? change.path.split(shortest_path)[1].split('/') : change.path.split('/'),//path_parts is an array with the path parts, and the 0th part will always be '' because of the split('/');
         old_value: change.old_value,
       }));
-      const old_value = rerooted_affected_changes.reduce((reverted, change) => undo(reverted, change, 1), shortest_path_subobjectument);
+      const old_value = rerooted_affected_changes.reduce((reverted, change) => undo(reverted, change, 1), shortest_path_subobjectument); //the undo fn is called with 1 because we want to skip the 0th value that is always ''. We do this way for performance reasons.
       const rerooted_requested_path = shortest_path ? path.split(shortest_path)[1] : path;
       return getPathValue(old_value, rerooted_requested_path);
     }

--- a/lib/undo.js
+++ b/lib/undo.js
@@ -14,22 +14,18 @@
  *
  * Returns: a new object
  */
-const undo = (object, change) => {
-  if(change.path === ''){
+const undo = (object, change, change_idx) => {
+  if(!change.path[change_idx]){
     return change.old_value;
   }else{
-    const change_path_splitted = change.path.split('/');
-    const change_first_path_part = change_path_splitted[1];
-    const rest_path_parts = change_path_splitted.splice(2);
+    const change_first_path_part = change.path[change_idx];
     if(object && (object.schema || object.constructor.name === 'Object')){//Under this reverted types we have to go deeper with the recursion
       const object_keys = object.schema && Object.keys(object.schema.paths) || object.constructor.name === 'Object' && Object.keys(object)
       const result = {};
       for(const key of object_keys){
         const value = object.schema && object.get(key) || object[key];
         if(change_first_path_part === key){//This change affects to this key, so we go deep inside
-          const rerooted_change_pointer = rest_path_parts.join('/'); //if the rerooted change's path is the empty string, we don't want the path to be /.
-          const rerooted_change = {path: rerooted_change_pointer.length > 0 ? `/${rerooted_change_pointer}` : rerooted_change_pointer, old_value: change.old_value};
-          result[key] = undo(value, rerooted_change);
+          result[key] = undo(value, change, change_idx + 1);
         }else{//This change does not affect to this object key, so we return the current objectument key value
           result[key] = value;
         }
@@ -38,9 +34,7 @@ const undo = (object, change) => {
     }else if(object instanceof Array){
       return object.map((value, index) => {//Here the index will be the first path part from the change's path.
         if(change_first_path_part === String(index)){//This change affects to this item, so we have to go deeper over this item
-          const rerooted_change_pointer = rest_path_parts.join('/'); //if the rerooted change's path is the empty string, we don't want the path to be /.
-          const rerooted_change = {path: rerooted_change_pointer.length > 0 ? `/${rerooted_change_pointer}` : rerooted_change_pointer, old_value: change.old_value};
-          return undo(value, rerooted_change);
+          return undo(value, change, change_idx + 1);
         }else{//This change does not affect to this object key, so we return the current objectument key value
           return value;
         }

--- a/lib/undo.js
+++ b/lib/undo.js
@@ -9,24 +9,31 @@
  * @param object: The object that we want to undo the change to. It can be a Mongoose document.
  * @param change: Object describing the change.
  * @@change specification:
- * @@@path: [mandatory] String in JSON pointer format.
+ * @@@path_parts: [mandatory] Array of strings where each string is a path part.
  * @@@old_value: [optional] any value.
+ * @paramchange_path_part_idx: integer representing the index of the path part for the current change path. It will start always in 1 because the change's path_parts 0th part will always be '', and we want to skip it.
  *
  * Returns: a new object
  */
-const undo = (object, change, change_idx) => {
-  if(!change.path[change_idx]){
+const undo = (object, change, change_path_part_idx) => {
+  if(!change.path_parts[change_path_part_idx]){//The change.path_parts array is going to hold always strings, so if we find a nullish value it is going to be an undefined because we are checking the array.length value, and this means that we have reached the end of the path specified by the change, so we have to return at this point the change's old value.
     return change.old_value;
   }else{
-    const change_first_path_part = change.path[change_idx];
+    const change_first_path_part = change.path_parts[change_path_part_idx];
     if(object && (object.schema || object.constructor.name === 'Object')){//Under this reverted types we have to go deeper with the recursion
       const object_keys = object.schema && Object.keys(object.schema.paths) || object.constructor.name === 'Object' && Object.keys(object)
       const result = {};
       for(const key of object_keys){
         const value = object.schema && object.get(key) || object[key];
         if(change_first_path_part === key){//This change affects to this key, so we go deep inside
-          result[key] = undo(value, change, change_idx + 1);
+          result[key] = undo(value, change, change_path_part_idx + 1);//Go depeer in the change's path increasing the change_path_part_idx.
         }else{//This change does not affect to this object key, so we return the current objectument key value
+          //This is going to be executed the most part of the time because only one path is changed, the rest are references, so we have to do this the fastest we can.
+          //That's why inside the change object we have a path_parts instead of a path
+          //because if we had the change path as in the previous version, we had to create the array inside this function, that it is called
+          //a lot of times, so at the end, you executed the path's split function at least as many time as keys the object had.
+          //With this version, we already have the path in array format, and we can iterate the array with an index resulting in a much
+          //efficient way of undoing the changes.
           result[key] = value;
         }
       }
@@ -34,7 +41,7 @@ const undo = (object, change, change_idx) => {
     }else if(object instanceof Array){
       return object.map((value, index) => {//Here the index will be the first path part from the change's path.
         if(change_first_path_part === String(index)){//This change affects to this item, so we have to go deeper over this item
-          return undo(value, change, change_idx + 1);
+          return undo(value, change, change_path_part_idx + 1);
         }else{//This change does not affect to this object key, so we return the current objectument key value
           return value;
         }


### PR DESCRIPTION
Lo primero de lo que hablamos hoy. Evitar splitear el path constantemente, llamando al undo con el path ya spliteado en el change y moviendo un indice para indicar el lugar actual.

Se que esto hace que el path ya no sea un jsonpointer, pero con undo es una funcion pura y la mejora de rendimiento es importante, creo que merece la pena.